### PR TITLE
feat(security): require Basic Auth on eureka-server

### DIFF
--- a/authentication/src/main/resources/application-dev.yml
+++ b/authentication/src/main/resources/application-dev.yml
@@ -69,7 +69,7 @@ auth:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 
 management:

--- a/catalog/src/main/resources/application-dev.yml
+++ b/catalog/src/main/resources/application-dev.yml
@@ -84,7 +84,7 @@ logging:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 
 #Prometheus (and other data loggers)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,8 @@ services:
     container_name: eureka-server-1
     environment:
       EUREKA_INSTANCE_HOSTNAME: eureka-server-1
+      EUREKA_USERNAME: ${EUREKA_USERNAME}
+      EUREKA_PASSWORD: ${EUREKA_PASSWORD}
     ports:
       - "8761:8761"
     restart: unless-stopped
@@ -185,6 +187,8 @@ services:
     container_name: eureka-server-2
     environment:
       EUREKA_INSTANCE_HOSTNAME: eureka-server-2
+      EUREKA_USERNAME: ${EUREKA_USERNAME}
+      EUREKA_PASSWORD: ${EUREKA_PASSWORD}
     ports:
       - "8762:8761"
     restart: unless-stopped

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eureka-server/src/main/java/com/ganchevdimitarg/config/SecurityConfig.java
+++ b/eureka-server/src/main/java/com/ganchevdimitarg/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.ganchevdimitarg.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Eureka peer/client replication authenticates via HTTP Basic credentials embedded in
+ * the {@code defaultZone} URL — {@code RestTemplateTransportClientFactory} parses them
+ * automatically, so no custom interceptor is needed on this side.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(a -> a
+                        .requestMatchers("/actuator/health").permitAll()
+                        .anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+}

--- a/eureka-server/src/main/resources/application.yml
+++ b/eureka-server/src/main/resources/application.yml
@@ -10,6 +10,10 @@ spring:
   cloud:
     compatibility-verifier:
       enabled: false
+  security:
+    user:
+      name: ${EUREKA_USERNAME:eureka}
+      password: ${EUREKA_PASSWORD}
 
 eureka:
   instance:
@@ -18,7 +22,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: ${EUREKA_PEER_ZONES:http://eureka-server-1:8761/eureka/,http://eureka-server-2:8761/eureka/}
+      defaultZone: ${EUREKA_PEER_ZONES:http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@eureka-server-1:8761/eureka/,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@eureka-server-2:8761/eureka/}
 
 management:
   otlp:

--- a/gateway/src/main/resources/application-dev.yml
+++ b/gateway/src/main/resources/application-dev.yml
@@ -140,7 +140,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
     fetch-registry: true
     register-with-eureka: true
 

--- a/notification/src/main/resources/application-dev.yml
+++ b/notification/src/main/resources/application-dev.yml
@@ -79,7 +79,7 @@ logging:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 
 #Prometheus (and other data loggers)

--- a/order/src/main/resources/application-dev.yml
+++ b/order/src/main/resources/application-dev.yml
@@ -76,7 +76,7 @@ logging:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 
 #Prometheus (and other data loggers)

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -61,7 +61,7 @@ logging:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 #Prometheus (and other data loggers)
 management:

--- a/profile/src/main/resources/application-dev.yml
+++ b/profile/src/main/resources/application-dev.yml
@@ -62,7 +62,7 @@ logging:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka,http://localhost:8762/eureka
+      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8761/eureka,http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD}@localhost:8762/eureka
 
 #Prometheus (and other data loggers)
 management:


### PR DESCRIPTION
Stacked on #21 - only the last commit (`feat(security): require Basic Auth on eureka-server`) is new in this PR.

## Summary
- `eureka-server` ran with no authentication at all - any network peer could read the full service registry (already a tracked High-severity finding in the prior production-readiness review). Closes it now that HA (#21) makes replication a two-instance concern.
- `eureka-server`: add `spring-boot-starter-security` + `SecurityConfig` permitting only `/actuator/health` unauthenticated, HTTP Basic on everything else. Credentials from `spring.security.user.name/password` (`EUREKA_USERNAME`/`EUREKA_PASSWORD` env vars, no inline defaults for the password).
- Peer `defaultZone` (both instances) and all 7 business services' `defaultZone` now embed the same credentials in the URL - Eureka's `RestTemplateTransportClientFactory` parses Basic Auth from the URI automatically, no custom interceptor needed.
- `docker-compose.yml`: pass `EUREKA_USERNAME`/`EUREKA_PASSWORD` through to both `eureka-server` instances.

## Test plan
- [x] Unauthenticated `GET /eureka/apps` -> 401
- [x] Authenticated `GET /eureka/apps` -> 200
- [x] Unauthenticated `GET /actuator/health` -> 200 (Docker `HEALTHCHECK` unaffected)
- [x] Both peers still see each other as `UP` post-auth
- [x] `./mvnw -f order/pom.xml clean verify`, `gateway`, `catalog` - all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
