### PR TITLE
feat(order): resolve catalog/profile/payment via Eureka lb://

### DIFF
--- a/order/pom.xml
+++ b/order/pom.xml
@@ -85,6 +85,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
         </dependency>
         <dependency>

--- a/order/src/main/java/com/ganchevdimitarg/order/config/RestClientConfig.java
+++ b/order/src/main/java/com/ganchevdimitarg/order/config/RestClientConfig.java
@@ -1,6 +1,7 @@
 package com.ganchevdimitarg.order.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
@@ -19,7 +20,10 @@ import java.time.Duration;
 /**
  * WebMVC outbound HTTP: blocking {@link RestClient} carrying an OAuth2 client-credentials
  * bearer token. Replaces the reactive {@code WebClient} setup — reactive types belong only
- * in {@code gateway}.
+ * in {@code gateway}. The builder is {@link LoadBalanced} so {@code lb://<service-id>} URIs
+ * resolve against Eureka via Spring Cloud LoadBalancer's blocking client — this is the
+ * WebMVC-side equivalent of gateway's reactive {@code lb://} route filter, not the same
+ * mechanism.
  */
 @Configuration
 public class RestClientConfig {
@@ -46,7 +50,14 @@ public class RestClientConfig {
     }
 
     @Bean
-    RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
+    @LoadBalanced
+    RestClient.Builder loadBalancedRestClientBuilder() {
+        return RestClient.builder();
+    }
+
+    @Bean
+    RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager,
+                           @LoadBalanced RestClient.Builder loadBalancedBuilder) {
         OAuth2ClientHttpRequestInterceptor requestInterceptor =
                 new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
         requestInterceptor.setClientRegistrationIdResolver(request -> defaultClientRegistrationId);
@@ -59,7 +70,7 @@ public class RestClientConfig {
                         .build());
         requestFactory.setReadTimeout(Duration.ofSeconds(5));
 
-        return RestClient.builder()
+        return loadBalancedBuilder
                 .requestFactory(requestFactory)
                 .requestInterceptor(requestInterceptor)
                 .build();

--- a/order/src/main/resources/application-dev.yml
+++ b/order/src/main/resources/application-dev.yml
@@ -163,7 +163,7 @@ resilience4j.timelimiter:
 
 catalog:
   base:
-    uri: ${CATALOG_SERVICE_BASE_URI:http://127.0.0.1:8084/api/v1}
+    uri: lb://catalog-service/api/v1
   service:
     products:
       get:
@@ -171,7 +171,7 @@ catalog:
 
 profile:
   base:
-    uri: ${PROFILE_SERVICE_BASE_URI:http://127.0.0.1:8083/api/v1}
+    uri: lb://profile-service/api/v1
   service:
     get:
       uri: ${profile.base.uri}/profile/get-by-username?username=
@@ -180,7 +180,7 @@ profile:
 
 payment:
   base:
-    uri: ${PAYMENT_SERVICE_BASE_URI:http://127.0.0.1:8087/api/v1}
+    uri: lb://payment-service/api/v1
   service:
     customer:
       post:


### PR DESCRIPTION
Stacked on #22 - only the last commit (`feat(order): resolve catalog/profile/payment via Eureka lb://`) is new in this PR.

## Summary
- `order`'s outbound calls to profile/catalog/payment used hardcoded plain hosts (`CATALOG_SERVICE_BASE_URI` et al.), bypassing Eureka entirely even though every other piece of routing in the fleet goes through it - no real load balancing or failover when a downstream scales beyond one instance.
- `order/pom.xml`: add `spring-cloud-starter-loadbalancer`.
- `RestClientConfig`: qualify the `RestClient.Builder` as `@LoadBalanced` so `lb://<service-id>` resolves via `BlockingLoadBalancerClient` before each request. This is the WebMVC/blocking equivalent of gateway's reactive `lb://` route filter, not the same mechanism. Existing OAuth2 bearer interceptor and 2s/5s timeouts unchanged.
- `application-dev.yml`: catalog/profile/payment base URIs now `lb://catalog-service`, `lb://profile-service`, `lb://payment-service`.

## Test plan
- [x] `./mvnw -f order/pom.xml clean verify` - green
- [ ] **Not done in this PR**: a live end-to-end `lb://` resolution against a running Eureka+catalog/profile/payment stack (needs Postgres/Vault/Redis/authentication-service/catalog all up together) - do this manually before deploying. Unit tests use `MockRestServiceServer` bound to their own `RestClient.Builder`, bypassing `RestClientConfig` entirely, so they don't exercise the load-balancer wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
