### PR TITLE
perf(order): fetch profile and catalog concurrently

### DIFF
--- a/catalog/CLAUDE.md
+++ b/catalog/CLAUDE.md
@@ -47,8 +47,9 @@ read the root file first.
 ```
 catalog auto-manages its own data plane (PG writer/reader, Redis, Kafka) via
 `catalog/compose.yaml` on `spring-boot:run` (dev only; tests use Testcontainers). Shared
-platform services (Vault `:8200`, Eureka `:8761`, auth `:8082`, OTLP `:4318`) come from the
-root `docker-compose`. Env: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `VAULT_DEV_ROOT_TOKEN_ID`.
+platform services (Vault `:8200`, Eureka `:8761`/`:8762` — 2 HA peers, auth `:8082`,
+OTLP `:4318`) come from the root `docker-compose`. Env: `POSTGRES_USER`,
+`POSTGRES_PASSWORD`, `VAULT_DEV_ROOT_TOKEN_ID`, `EUREKA_USERNAME`, `EUREKA_PASSWORD`.
 
 ## Known migration gaps
 - Source fully migrated to Boot 4.1.0 / Java 25 on the single `com.ganchevdimitarg.catalog`

--- a/order/src/main/java/com/ganchevdimitarg/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/ganchevdimitarg/order/service/OrderServiceImpl.java
@@ -38,6 +38,10 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -76,15 +80,16 @@ public class OrderServiceImpl implements OrderService {
             throw new NotFoundException("Order not found for user " + authenticationName);
         }
 
-        UserDto userInfo = getProfile(authenticationName);
+        DependencyResult deps = fetchProfileAndProducts(authenticationName, ItemRequestDto.builder()
+                .items(orderDto.items().stream().map(OrderLineDto::productId).toList())
+                .build());
+        UserDto userInfo = deps.profile();
         if (userInfo == null || userInfo.username() == null || userInfo.username().isBlank()) {
             throw new ConflictException("No profile for " + authenticationName
                     + "; register and add a card before ordering");
         }
 
-        List<ProductResponseDto> products = getProducts(ItemRequestDto.builder()
-                .items(orderDto.items().stream().map(OrderLineDto::productId).toList())
-                .build());
+        List<ProductResponseDto> products = deps.products();
         long amount = computeAmountInCents(orderDto.items(), products);
 
         // 1. Commit the order before any money moves, so it survives a payment failure.
@@ -164,14 +169,16 @@ public class OrderServiceImpl implements OrderService {
     public OrderResponseDto getOrder(long orderNumber, String authenticationName) {
         Order order = loadOwnedOrder(orderNumber, authenticationName);
 
-        UserDto userInfo = getProfile(authenticationName);
-        List<ProductResponseDto> productInfo = getProducts(ItemRequestDto.builder()
+        // Pure outbound HTTP only — never fork a call that touches orderDao/the persistence
+        // context here: this method is @Transactional and Hibernate's session is bound to
+        // the calling thread, not visible to a forked virtual thread.
+        DependencyResult deps = fetchProfileAndProducts(authenticationName, ItemRequestDto.builder()
                 .items(order.getItems().stream().map(Item::getProductId).toList())
                 .build());
 
         return OrderResponseDto.builder()
-                .userInfo(userInfo)
-                .productInfo(productInfo)
+                .userInfo(deps.profile())
+                .productInfo(deps.products())
                 .orderNumber(order.getOrderNumber())
                 .deliveryComment(order.getDeliveryComment())
                 .createdOn(order.getCreatedOn())
@@ -244,6 +251,36 @@ public class OrderServiceImpl implements OrderService {
             throw new NotFoundException("Order not found: " + orderNumber);
         }
         return order;
+    }
+
+    private record DependencyResult(UserDto profile, List<ProductResponseDto> products) { }
+
+    /**
+     * Fetch profile and catalog data concurrently — both are pure outbound HTTP calls with
+     * no shared state, so running them on separate virtual threads is safe. Never fork a
+     * call that touches the JPA persistence context this way: Hibernate's session is bound
+     * to the calling thread, not visible to a task running on another one.
+     *
+     * <p>{@code StructuredTaskScope} (the documented house pattern for this) is still a
+     * preview API on this project's JDK 25 build and would require {@code --enable-preview}
+     * project-wide, so this uses {@link CompletableFuture} on a virtual-thread-per-task
+     * executor instead — same concurrency benefit, stable API.
+     */
+    private DependencyResult fetchProfileAndProducts(String username, ItemRequestDto productsRequest) {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            CompletableFuture<UserDto> profileFuture =
+                    CompletableFuture.supplyAsync(() -> getProfile(username), executor);
+            CompletableFuture<List<ProductResponseDto>> productsFuture =
+                    CompletableFuture.supplyAsync(() -> getProducts(productsRequest), executor);
+            CompletableFuture.allOf(profileFuture, productsFuture).join();
+            return new DependencyResult(profileFuture.join(), productsFuture.join());
+        } catch (CompletionException e) {
+            throw unwrap(e.getCause());
+        }
+    }
+
+    private static RuntimeException unwrap(Throwable t) {
+        return (t instanceof RuntimeException re) ? re : new ServiceUnavailableException("Dependency lookup failed");
     }
 
     private UserDto getProfile(String username) {

--- a/order/src/test/java/com/ganchevdimitarg/order/service/OrderServiceImplTest.java
+++ b/order/src/test/java/com/ganchevdimitarg/order/service/OrderServiceImplTest.java
@@ -77,7 +77,9 @@ class OrderServiceImplTest {
     @BeforeEach
     void setUp() {
         RestClient.Builder builder = RestClient.builder();
-        server = MockRestServiceServer.bindTo(builder).build();
+        // profile and catalog now run concurrently (fetchProfileAndProducts), so the two
+        // requests can hit the mock server in either order.
+        server = MockRestServiceServer.bindTo(builder).ignoreExpectOrder(true).build();
         orderService = new OrderServiceImpl(orderDao, builder.build(), circuitBreakerFactory,
                 chargeService, statusHistoryDao, orderPersistence);
         ReflectionTestUtils.setField(orderService,
@@ -132,6 +134,10 @@ class OrderServiceImplTest {
     void should_throwConflict_when_noProfileRegistered() throws Exception {
         runSupplier();
         stubProfile(UserDto.builder().username("").build());
+        // profile and catalog are now fetched concurrently, so catalog is called even though
+        // the profile turns out to be invalid — stub it so the concurrent call has a response.
+        stubCatalog(List.of(ProductResponseDto.builder().id("p_1").name("Widget")
+                .price(new BigDecimal("10.00")).build()));
 
         assertThatThrownBy(() -> orderService.createOrder(orderFor("john", new OrderLineDto("p_1", 1)), "john"))
                 .isInstanceOf(ConflictException.class);


### PR DESCRIPTION
Stacked on #23 - only the last 2 commits (`perf(order): fetch profile and catalog concurrently`, `docs(catalog): note eureka HA peer ports and required env vars`) are new in this PR.

## Summary
- `createOrder`/`getOrder` called profile then catalog sequentially even though both are independent outbound HTTP reads - a missed fan-out opportunity flagged in the prior production-readiness review.
- New `fetchProfileAndProducts()` runs `getProfile()`/`getProducts()` on a virtual-thread-per-task executor via `CompletableFuture`, joining both. `StructuredTaskScope` (the documented house pattern for this) is still a preview API on this project's JDK 25.0.3 build and would need `--enable-preview` project-wide, which is a much bigger decision than this change - `CompletableFuture` + virtual threads gets the same concurrency benefit on a stable API. Each dependency keeps its own circuit breaker; only the caller changed.
- Deliberate JPA constraint: never fork a call that touches `orderDao`/the persistence context this way - `getOrder()` is `@Transactional(readOnly = true)` and Hibernate's session is bound to the calling thread. Only pure outbound HTTP is forked.
- Scope: `ChargeServiceImpl`'s payment calls are untouched - `chargeCustomer` has a real data dependency on the prior call's `customerId`, so they cannot be parallelized.
- **Behavioral change**: `createOrder()` no longer short-circuits catalog when the profile turns out invalid - both calls now always fire concurrently, so an invalid-profile order attempt costs one extra outbound call + circuit-breaker invocation it didn't before.
- Also: small `catalog/CLAUDE.md` doc fix noting the Eureka HA peer ports (`:8761`/`:8762`) and new `EUREKA_USERNAME`/`EUREKA_PASSWORD` env vars.

## Test plan
- [x] `OrderServiceImplTest`: `MockRestServiceServer` now uses `ignoreExpectOrder(true)` since concurrent calls can hit the mock server in either order; `should_throwConflict_when_noProfileRegistered` gained a `stubCatalog()` since catalog is now called unconditionally
- [x] `./mvnw -f order/pom.xml clean verify` - green
- [x] `OrderServiceImplTest` run 20x in a row with no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
